### PR TITLE
feat: get state and progress of getSignature.

### DIFF
--- a/src/ledger-liquid-lib.d.ts
+++ b/src/ledger-liquid-lib.d.ts
@@ -96,6 +96,7 @@ export interface GetSignatureProgress extends ResponseInfo {
   inputTx: ProgressInfo;
   getSignature: ProgressInfo;
   total: ProgressInfo;
+  lastAccessTime: number;
 }
 
 export class LedgerLiquidWrapper {

--- a/src/ledger-liquid-lib.d.ts
+++ b/src/ledger-liquid-lib.d.ts
@@ -17,6 +17,12 @@ export enum AddressType {
   Bech32 = 'bech32',
 }
 
+export enum GetSignatureState {
+  AnalyzeUtxo = 'analyzeUtxo', // Preparation before 'input transaction'
+  InputTx = 'inputTx', // input transaction to ledger
+  GetSignature = 'getSignature', // request getSignature to ledger
+}
+
 export interface UtxoData {
   txid: string; // key(outpoint)
   vout: number; // key(outpoint)
@@ -77,6 +83,19 @@ export interface GetSignatureAddressResponse extends ResponseInfo {
 
 export interface GetDeviceListResponse extends ResponseInfo {
   deviceList: string[];
+}
+
+export interface ProgressInfo {
+  current: number;
+  total: number;
+}
+
+export interface GetSignatureProgress extends ResponseInfo {
+  currentState: GetSignatureState;
+  analyzeUtxo: ProgressInfo;
+  inputTx: ProgressInfo;
+  getSignature: ProgressInfo;
+  total: ProgressInfo;
 }
 
 export class LedgerLiquidWrapper {
@@ -199,4 +218,11 @@ export class LedgerLiquidWrapper {
     walletUtxoList: WalletUtxoData[], // sign target utxo list.
     authorizationSignature: string, // authorization signature (from backend)
   ): Promise<GetSignatureAddressResponse>;
+
+  /**
+   * Get state and progress of getSignature.
+   *
+   * @returns GetSignatureProgress.
+   */
+  getSignatureState(): GetSignatureProgress;
 }


### PR DESCRIPTION
getSignature()の実行状況取得APIとして、getSignatureStateを追加。getSignature()を実行しているオブジェクトと同一のオブジェクトを使用すること。

stateは以下の３つ。
- AnalyzeUtxo: WalletUtxoDataのチェック処理。descriptorを設定していれば時間はかからず。
- InputTx: Transaction情報をLedgerに投入する。txin/txoutの個数分だけ時間がかかる。（１つ１秒以下程度）
- GetSignature: signatureの取得。WalletUtxoDataの個数分だけ時間がかかる。（１つ５秒程度）

ProgressInfoのcurrent/totalがそれぞれの状態を表す。totalは最初から全て入っているが、currentは該当steteの処理中に加算され、該当state終了時にtotalと一致する。

getSignature呼び出しがない場合に本APIをコールした時は、正常終了かつProgressInfoのtotal値に0指定で返す。
また例外系のエラーとして以下を追加予定。
- timeout: ledgerからの応答が一定時間 (今の所15sec程度を予定) なかった場合に返却。ledgerの気持ちが分からないので原因は不明だが、USB再接続が必要だった。